### PR TITLE
016/iam update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # Secrets not to be shared
+credentials.csv
 .env
-accessKeys.csv

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ In the [S3](https://console.aws.amazon.com/s3) tab:
  buckets and in all lowercase characters.
 1.  Select `US Standard` for the `Region`.
 1.  Click `Create`.
-1.  Highlight your bucket and select the `Properties` tab on the right side.
+1.  Highlight your bucket by clicking on it and then select the `Properties` tab on the right side.
 1.  Open the `Permissions` dropdown in the right sidebar.
 1.  Click `Add bucket policy` near the bottom of the `Permissions` dropdown.
 1.  At the bottom of the `Bucket Policy Editor` modal,
  click `AWS Policy Generator`.  This opens the AWS Policy Generator page.
-1.  On the AWS Policy Generator page
+
+1.  On the AWS Policy Generator page:
 
     1.  Step 1: Select Policy Type
 
@@ -119,8 +120,8 @@ In the [S3](https://console.aws.amazon.com/s3) tab:
 
 1.  Return to the S3 tab.
 1.  Paste the bucket policy into the `Bucket Policy Editor` modal.
-1.  Click `Save`.
-1.  Click `Save` in the `Permissions` dropdown.
+1.  Click `Save` in the `Bucket Policy Editor` modal.
+1.  Then *also* Click `Save` in the `Permissions` dropdown.
 
 You have now created and granted access to an S3 bucket.
 

--- a/README.md
+++ b/README.md
@@ -56,21 +56,20 @@ In the [IAM](https://console.aws.amazon.com/iam) tab:
 1.  Click `Add User` near the top of the page.
 1.  Enter `wdi-upload` into the text box.
 1.  Under access type, check `Programmatic Access`
-1.  Click Next
-1.  Highlight Add User to Group
-1.  Click Next
+1.  Click `Next: Permissions`
+1.  Highlight Add User to Group (it will be by default)
+1.  Click `Next: Review`
 1.  Click create User
-_Then_
-1.  Click on your newly created user.
-1.  Click on the security credentials tab.
-1.  Click the small red `x` to the right of your existing access key to delete it.
-1.  Click `Create access key`
-1.  When complete, click `download .csv file` and save the CSV to this repository.(this is
-the only time you'll be able to see your access key, but you can generate a new one anytime
-and are encouraged to rotate them frequently)
-1.  Click `Download Credentials`.
+1. Under a green success message, click the `Download .csv` button.
+1. This will download a file called `credentials.csv`
 1.  Save the file `credentials.csv` to this repository.
-1.  Click `Close`
+
+**Note well:** credentials.csv contains `secrets`!
+Do not share them or store them in git.
+The [.gitignore](.gitignore) in this repository explicitly ignores this file. Altering the [.gitignore](.gitignore) file
+in this repository could result in your AWS credentials (credentials linked to *your* credit card information) being visible on Github. *NEVER COMMIT SECRETS TO GIT*
+
+1. Click `close` button to return to the users page.
 1.  Click on the newly created user.
 1.  Copy the `User ARN` _(Amazon Resource Name)_ at the top of the page and save it in [arn.txt](arn.txt).
 
@@ -79,10 +78,6 @@ We'll also need an `Access Key` _(Access Key Id and Secret Access Key)_ for this
  IAM User to upload files via the S3 API.
 The Access Key is contained in credentials.csv.
 
-**Note well:** credentials.csv contains `secrets`!
-Do not share them or store them in git.
-The [.gitignore](.gitignore) in this repository explicitly ignores this file. Altering the [.gitignore](.gitignore) file
-in this repository could result in your AWS credentials (credentials linked to *your* credit card information) being visible on Github. *NEVER COMMIT SECRETS TO GIT*
 
 ### Simple Storage Service (S3)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Using restrictive access control with AWS ensures that even if an identity is
 
 ## AWS S3 access control
 
-1.  Open the [AWS Consle](https://console.aws.amazon.com/console/) in your
+1.  Open the [AWS Console](https://console.aws.amazon.com/console/) in your
  browser
 1.  From the `AWS` console open tabs for
  `IAM` _(Identity and Access Management)_ and `S3` _(Simple Storage Service)_.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ In the [IAM](https://console.aws.amazon.com/iam) tab:
 1.  Enter `wdi-upload` into the text box.
 1.  Under access type, check `Programmatic Access`
 1.  Click `Next: Permissions`
-1.  Highlight Add User to Group (it will be by default)
+1.  Highlight `Add User to Group` (it will be by default)
 1.  Click `Next: Review`
-1.  Click create User
+1.  Click 'Create User'
 1. Under a green success message, click the `Download .csv` button.
 1. This will download a file called `credentials.csv`
 1.  Save the file `credentials.csv` to this repository.


### PR DESCRIPTION
This branch repairs erroneous changes made by @bengitscode in #13  merged from 016/master.

Most importantly, the `.gitignore` never should have been updated and doing so removed the only content it should have, `credentials.csv` and `.env`, while adding in the full [node-template .gitignore](https://github.com/ga-wdi-boston/node-template/blob/master/.gitignore).

Additionally, the IAM section had redundant steps and downright incorrect information due to my misunderstanding of the process. Those errors have been fixed, and the language further clarified.

S3 section was accurate but I added some more clarifying language there as well.

Any non-critical issues are open as issues, these are critical. 